### PR TITLE
Fix encodePayloadAsBinary method encodes packets to base64

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -346,7 +346,7 @@ exports.encodePayloadAsBinary = function (packets, callback) {
   }
 
   function encodeOne(p, doneCallback) {
-    exports.encodePacket(p, function(packet) {
+    exports.encodePacket(p, true, function(packet) {
 
       if (typeof packet === 'string') {
         var encodingLength = '' + Buffer.byteLength(packet, "utf8");


### PR DESCRIPTION
I believe it should encode to binary.
