### PR TITLE
Don't pass too many arguments

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -526,11 +526,10 @@ exports.decodePayloadAsBinary = function (data, binaryType, callback) {
       } catch (e) {
         // iPhone Safari doesn't let you apply to typed arrays
         var typed = new Uint8Array(msg);
-        var basic = new Array(typed.length);
+        msg = '';
         for (var i = 0; i < typed.length; i++) {
-          basic[i] = typed[i];
+          msg += String.fromCharCode(typed[i]);
         }
-        msg = String.fromCharCode.apply(null, basic);
       }
     }
     buffers.push(msg);


### PR DESCRIPTION
`.apply()` has a max argument length which was easily exceeded by a large buffer. This makes more calls to `String.fromCharCode` but is guaranteed not to throw a `RangeError`.

More on max argument size: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#Using_apply_and_built-in_functions
