### PR TITLE
Fix buffer encoding/decoding for payload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -358,7 +358,7 @@ exports.encodePayloadAsBinary = function (packets, callback) {
           sizeBuffer[i + 1] = parseInt(encodingLength[i], 10);
         }
         sizeBuffer[sizeBuffer.length - 1] = 255;
-        return doneCallback(null, Buffer.concat([sizeBuffer, new Buffer(packet, 'binary')]));
+        return doneCallback(null, Buffer.concat([sizeBuffer, new Buffer(packet, 'utf8')]));
       }
 
       var encodingLength = '' + packet.length;
@@ -407,7 +407,7 @@ exports.decodePayloadAsBinary = function (data, binaryType, callback) {
     var msgLength = parseInt(strLen, 10);
 
     var msg = bufferTail.slice(1, msgLength + 1);
-    if (isString) msg = msg.toString('binary');
+    if (isString) msg = msg.toString('utf8');
     buffers.push(msg);
     bufferTail = bufferTail.slice(msgLength + 1);
   }

--- a/test/parser.js
+++ b/test/parser.js
@@ -164,6 +164,20 @@ module.exports = function(parser) {
               });
           });
         });
+
+        it('should encode/decode multibyte strings as binary', function () {
+          var messages = ['cash money €€€', 'hi'];
+          var packets = messages.map(function(data) {
+            return {type: 'message', data: data};
+          });
+          encPayload(packets, true, function(data) {
+            decPayload(data,
+              function (packet, index, total) {
+                expect(packet.type).to.eql('message');
+                expect(packet.data).to.eql(messages[index]);
+              });
+          });
+        });
       });
   
       describe('decoding error handling', function () {


### PR DESCRIPTION
We have to use the same encoding for a buffer and calculating its length.
