### PR TITLE
fix decodePayloadAsBinary memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/lib/index.js
+++ b/lib/index.js
@@ -428,10 +428,16 @@ exports.decodePayloadAsBinary = function (data, binaryType, callback) {
   while (bufferTail.length > 0) {
     var strLen = '';
     var isString = bufferTail[0] === 0;
+    var numberTooLong = false;
     for (var i = 1; ; i++) {
       if (bufferTail[i] == 255)  break;
+      if (strLen.length > 310) {
+        numberTooLong = true;
+        break;
+      }
       strLen += '' + bufferTail[i];
     }
+    if(numberTooLong) return callback(err, 0, 1);
     bufferTail = bufferTail.slice(strLen.length + 1);
 
     var msgLength = parseInt(strLen, 10);

--- a/test/parser.js
+++ b/test/parser.js
@@ -192,6 +192,11 @@ module.exports = function(parser) {
             expect(packet).to.eql(err);
             expect(isLast).to.eql(true);
           });
+          decPayload(new Buffer([64]), function (packet, index, total) {
+            var isLast = index + 1 == total;
+            expect(packet).to.eql(err);
+            expect(isLast).to.eql(true);
+          });
         });
 
         it('should err on bad payload length', function () {


### PR DESCRIPTION
If `data` has no byte with the value 255, the `for` loop will not exit and `bufferTail` gets bigger and bigger until the nodejs server (in my case) crashes. 

`strLen.length > 310` (Number.MAX_VALUE is about 310 characters long)
