### PR TITLE
Handle invalid utf8 errors gracefully

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -193,7 +193,11 @@ exports.decodePacket = function (data, binaryType) {
       return exports.decodeBase64Packet(data.substr(1), binaryType);
     }
 
-    data = utf8.decode(data);
+    try {
+      data = utf8.decode(data);
+    } catch (e) {
+      return err;
+    }
     var type = data.charAt(0);
 
     if (Number(type) != type || !packetslist[type]) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,11 @@ exports.decodePacket = function (data, binaryType) {
     }
 
     var type = data.charAt(0);
-    data = utf8.decode(data);
+    try {
+      data = utf8.decode(data);
+    } catch (e) {
+      return err;
+    }
 
     if (Number(type) != type || !packetslist[type]) {
       return err;

--- a/test/parser.js
+++ b/test/parser.js
@@ -122,6 +122,10 @@ module.exports = function(parser) {
         it('should disallow inexistent types', function () {
           expect(decode('94103')).to.eql(err);
         });
+
+        it('should disallow invalid utf8', function () {
+          expect(decode('4\uffff')).to.eql(err);
+        });
       });
     });
 
@@ -227,6 +231,14 @@ module.exports = function(parser) {
           });
           // line 137
           decPayload('1:a2:b', function (packet, index, total) {
+            var isLast = index + 1 == total;
+            expect(packet).to.eql(err);
+            expect(isLast).to.eql(true);
+          });
+        });
+
+        it('should err on invalid utf8', function () {
+          decPayload('2:4\uffff', function (packet, index, total) {
             var isLast = index + 1 == total;
             expect(packet).to.eql(err);
             expect(isLast).to.eql(true);


### PR DESCRIPTION
An invalid UTF8 error should be converted to an error packet, IMO. It has the same behavior when another type of error happens.
