### PR TITLE
Avoid sending Blobs on PhantomJS (as on Android)

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -18,6 +18,20 @@ var utf8 = require('utf8');
 var isAndroid = navigator.userAgent.match(/Android/i);
 
 /**
+ * Check if we are running in PhantomJS.
+ * Uploading a Blob with PhantomJS does not work correctly, as reported here:
+ * https://github.com/ariya/phantomjs/issues/11395
+ * @type boolean
+ */
+var isPhantomJS = /PhantomJS/i.test(navigator.userAgent);
+
+/**
+ * When true, avoids using Blobs to encode payloads.
+ * @type boolean
+ */
+var dontSendBlobs = isAndroid || isPhantomJS;
+
+/**
  * Current protocol version.
  */
 
@@ -139,7 +153,7 @@ function encodeBlob(packet, supportsBinary, callback) {
     return exports.encodeBase64Packet(packet, callback);
   }
 
-  if (isAndroid) {
+  if (dontSendBlobs) {
     return encodeBlobAsArrayBuffer(packet, supportsBinary, callback);
   }
 
@@ -272,7 +286,7 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
   }
 
   if (supportsBinary) {
-    if (Blob && !isAndroid) {
+    if (Blob && !dontSendBlobs) {
       return exports.encodePayloadAsBlob(packets, callback);
     }
 


### PR DESCRIPTION
This pull request fixes an issue with socket.io on PhantomJS.

Uploading a `Blob` with PhantomJS does not work correctly, as reported here:
https://github.com/ariya/phantomjs/issues/11395
