### PR TITLE
Encode into binary only if needed

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -3,6 +3,7 @@
  */
 
 var keys = require('./keys');
+var hasBinary = require('has-binary');
 var sliceBuffer = require('arraybuffer.slice');
 var base64encoder = require('base64-arraybuffer');
 var after = require('after');
@@ -285,7 +286,7 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
     supportsBinary = null;
   }
 
-  if (supportsBinary) {
+  if (supportsBinary && hasBinary(packets)) {
     if (Blob && !dontSendBlobs) {
       return exports.encodePayloadAsBlob(packets, callback);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
  */
 
 var utf8 = require('utf8');
+var hasBinary = require('has-binary');
 var after = require('after');
 var keys = require('./keys');
 
@@ -226,7 +227,7 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
     supportsBinary = null;
   }
 
-  if (supportsBinary) {
+  if (supportsBinary && hasBinary(packets)) {
     return exports.encodePayloadAsBinary(packets, callback);
   }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "after": "0.8.1",
     "arraybuffer.slice": "0.0.6",
     "blob": "0.0.2",
+    "has-binary": "0.1.5",
     "utf8": "2.0.0"
   },
   "scripts": {

--- a/test/parser.js
+++ b/test/parser.js
@@ -153,6 +153,15 @@ module.exports = function(parser) {
         });
       });
 
+      describe('basic functionality', function () {
+        it('should encode string payloads as strings even if binary supported', function (done) {
+          encPayload([{ type: 'ping' }, { type: 'post' }], true, function(data) {
+            expect(data).to.be.a('string');
+            done();
+          });
+        });
+      });
+
       describe('encoding and decoding', function () {
         var seen = 0;
         it('should encode/decode packets', function (done) {


### PR DESCRIPTION
Adds a check for binary data in the payload (`.encodePayload`) with `has-binary`.

This way we don't make unnecessarily complicated decoding of strings back from the binary format when we really don't need to (since all packets only contain strings). We also avoid OPTIONS requests when the octet-stream content type is not really needed, like in the case of an actual binary payload.

Attached is a test case that fails currently, but starts passing with the applied check for binary.
