### PR TITLE
Use travis matrix for better test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,39 @@ env:
   global:
   - secure: ZS6AzV1n1K1exomhZoK0SorBHEy4/7/qdk1p5/dm0tQdStSVwRDJyQk5wUIgJFsJaVlN8O/MH8LBkiLlalohR/DdE2ZtkNJqfMnetE/ZqPX7r8mzwDasnHJNJnKWJlBVqOpy7hciiPV2yZGIJoe2OQfwWxFEcLJ6NGOXCEkyLAg=
   - secure: hcqk+nIqzrwJSQs+5T1sKN4YiCghQdP849RjH64bb7Ayslh+o0DmihTE3Wl+cCWFcRBvwBJdmDV2gJpsVcODTc2VdOrJnv8ezfQ8zvAyDZFYxno47PtbjQUi0By2wBPp6zlfigcnXxQ2z6997EDRvsI4VgQVqKsGLot4cMU9oz0=
+matrix:
+  include:
+  - node_js: '0.10'
+    env: BROWSER_NAME=chrome BROWSER_VERSION=latest
+  - node_js: '0.10'
+    env: BROWSER_NAME=safari BROWSER_VERSION=latest
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=6
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=7
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=8
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=9
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=10 BROWSER_PLATFORM="Windows 2012"
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=latest BROWSER_PLATFORM="Windows 2012"
+  - node_js: '0.10'
+    env: BROWSER_NAME=iphone BROWSER_VERSION=4.3
+  - node_js: '0.10'
+    env: BROWSER_NAME=iphone BROWSER_VERSION=5.1
+  - node_js: '0.10'
+    env: BROWSER_NAME=iphone BROWSER_VERSION=6.1
+  - node_js: '0.10'
+    env: BROWSER_NAME=iphone BROWSER_VERSION=7.1
+  - node_js: '0.10'
+    env: BROWSER_NAME=android BROWSER_VERSION=4.0
+  - node_js: '0.10'
+    env: BROWSER_NAME=android BROWSER_VERSION=4.1
+  - node_js: '0.10'
+    env: BROWSER_NAME=android BROWSER_VERSION=4.2
+  - node_js: '0.10'
+    env: BROWSER_NAME=android BROWSER_VERSION=4.3
+  - node_js: '0.10'
+    env: BROWSER_NAME=android BROWSER_VERSION=4.4

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,25 @@
 REPORTER = dot
 
 test:
+	@if [ "x$(BROWSER_NAME)" = "x" ]; then make test-node; else make test-zuul; fi
+
+test-node:
 	@./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
 		test/index.js
-	@./node_modules/.bin/zuul -- test/index.js
+
+test-zuul:
+	@if [ "x$(BROWSER_PLATFORM)" = "x" ]; then \
+		./node_modules/zuul/bin/zuul \
+		--browser-name $(BROWSER_NAME) \
+		--browser-version $(BROWSER_VERSION) \
+		test/index.js; \
+		else \
+		./node_modules/zuul/bin/zuul \
+		--browser-name $(BROWSER_NAME) \
+		--browser-version $(BROWSER_VERSION) \
+		--browser-platform "$(BROWSER_PLATFORM)" \
+		test/index.js; \
+	fi
 
 .PHONY: test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "mocha": "*",
     "expect.js": "*",
-    "zuul": "1.6.3"
+    "zuul": "1.10.2"
   },
   "dependencies": {
     "base64-arraybuffer": "0.1.2",


### PR DESCRIPTION
- Bumps Zuul to include support for running individual browsers through env variables
- Adds the same set of browsers to test against as is used by engine.io-client in `.travis.yml`
