### PR TITLE
Fix iojs 3.0 Buffer.buffer issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ exports.encodePacket = function (packet, supportsBinary, utf8encode, callback) {
 
   if (Buffer.isBuffer(packet.data)) {
     return encodeBuffer(packet, supportsBinary, callback);
-  } else if (packet.data && packet.data.buffer instanceof ArrayBuffer) {
+  } else if (packet.data && (packet.data.buffer || packet.data) instanceof ArrayBuffer) {
     return encodeArrayBuffer(packet, supportsBinary, callback);
   }
 
@@ -94,7 +94,7 @@ function encodeBuffer(packet, supportsBinary, callback) {
 
 function encodeArrayBuffer(packet, supportsBinary, callback) {
 
-  var data = packet.data.buffer;
+  var data = packet.data.buffer || packet.data;
 
   if (!supportsBinary) {
     return exports.encodeBase64Packet(packet, callback);
@@ -119,7 +119,7 @@ function encodeArrayBuffer(packet, supportsBinary, callback) {
 
 exports.encodeBase64Packet = function(packet, callback){
 
-  if (packet.data.buffer instanceof ArrayBuffer) {
+  if (!Buffer.isBuffer(packet.data)) {
     var buf = new Buffer(packet.data.byteLength);
     for (var i = 0; i < buf.length; i++) {
       buf[i] = packet.data[i];

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,13 +60,9 @@ exports.encodePacket = function (packet, supportsBinary, utf8encode, callback) {
     utf8encode = null;
   }
 
-  var data = (packet.data === undefined)
-    ? undefined
-    : packet.data.buffer || packet.data;
-
-  if (Buffer.isBuffer(data)) {
+  if (Buffer.isBuffer(packet.data)) {
     return encodeBuffer(packet, supportsBinary, callback);
-  } else if (data instanceof ArrayBuffer) {
+  } else if (packet.data && packet.data.buffer instanceof ArrayBuffer) {
     return encodeArrayBuffer(packet, supportsBinary, callback);
   }
 
@@ -97,9 +93,8 @@ function encodeBuffer(packet, supportsBinary, callback) {
 }
 
 function encodeArrayBuffer(packet, supportsBinary, callback) {
-  var data = (packet.data === undefined)
-    ? undefined
-    : packet.data.buffer || packet.data;
+
+  var data = packet.data.buffer;
 
   if (!supportsBinary) {
     return exports.encodeBase64Packet(packet, callback);
@@ -123,11 +118,11 @@ function encodeArrayBuffer(packet, supportsBinary, callback) {
  */
 
 exports.encodeBase64Packet = function(packet, callback){
-  var data = packet.data.buffer || packet.data;
-  if (data instanceof ArrayBuffer) {
-    var buf = new Buffer(data.byteLength);
+
+  if (packet.data.buffer instanceof ArrayBuffer) {
+    var buf = new Buffer(packet.data.byteLength);
     for (var i = 0; i < buf.length; i++) {
-      buf[i] = data[i];
+      buf[i] = packet.data[i];
     }
     packet.data = buf;
   }


### PR DESCRIPTION
Fix reading buffers in iojs 3.0 where `packet.data.buffer` is an ArrayBuffer even on normal Buffers.