### PR TITLE
Fix ArrayBuffer encoding in base64 string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,8 @@ exports.encodePacket = function (packet, supportsBinary, utf8encode, callback) {
   if (Buffer.isBuffer(packet.data)) {
     return encodeBuffer(packet, supportsBinary, callback);
   } else if (packet.data && (packet.data.buffer || packet.data) instanceof ArrayBuffer) {
-    return encodeArrayBuffer(packet, supportsBinary, callback);
+    packet.data = arrayBufferToBuffer(packet.data);
+    return encodeBuffer(packet, supportsBinary, callback);
   }
 
   // Sending data as a utf-8 string
@@ -92,24 +93,6 @@ function encodeBuffer(packet, supportsBinary, callback) {
   return callback(Buffer.concat([typeBuffer, data]));
 }
 
-function encodeArrayBuffer(packet, supportsBinary, callback) {
-
-  var data = packet.data.buffer || packet.data;
-
-  if (!supportsBinary) {
-    return exports.encodeBase64Packet(packet, callback);
-  }
-
-  var contentArray = new Uint8Array(data);
-  var resultBuffer = new Buffer(1 + data.byteLength);
-
-  resultBuffer[0] = packets[packet.type];
-  for (var i = 0; i < contentArray.length; i++){
-    resultBuffer[i+1] = contentArray[i];
-  }
-  return callback(resultBuffer);
-}
-
 /**
  * Encodes a packet with binary data in a base64 string
  *
@@ -118,13 +101,8 @@ function encodeArrayBuffer(packet, supportsBinary, callback) {
  */
 
 exports.encodeBase64Packet = function(packet, callback){
-
   if (!Buffer.isBuffer(packet.data)) {
-    var buf = new Buffer(packet.data.byteLength);
-    for (var i = 0; i < buf.length; i++) {
-      buf[i] = packet.data[i];
-    }
-    packet.data = buf;
+    packet.data = arrayBufferToBuffer(packet.data);
   }
 
   var message = 'b' + packets[packet.type];
@@ -362,6 +340,26 @@ function stringToBuffer(string) {
     buf.writeUInt8(string.charCodeAt(i), i);
   }
   return buf;
+}
+
+/**
+ *
+ * Converts an ArrayBuffer to a Buffer
+ *
+ * @api private
+ */
+
+function arrayBufferToBuffer(data) {
+  // data is either an ArrayBuffer or ArrayBufferView.
+  var array = new Uint8Array(data.buffer || data);
+  var length = data.byteLength || data.length;
+  var offset = data.byteOffset || 0;
+  var buffer = new Buffer(length);
+
+  for (var i = 0; i < length; i++) {
+    buffer[i] = array[offset + i];
+  }
+  return buffer;
 }
 
 /**

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -89,4 +89,53 @@ describe('parser', function() {
         });
     });
   });
+
+  it('should encode/decode an ArrayBuffer as b64', function(done) {
+    var buffer = new ArrayBuffer(4);
+    var dataview = new DataView(buffer);
+    for (var i = 0; i < buffer.byteLength ; i++) dataview.setInt8(i, i);
+
+    encode({ type: 'message', data: buffer }, function(encoded) {
+      var decoded = decode(encoded, 'arraybuffer');
+      expect(decoded).to.eql({ type: 'message', data: buffer });
+      expect(new Uint8Array(decoded.data)).to.eql(new Uint8Array(buffer));
+      done();
+    });
+  });
+
+  it('should encode/decode an ArrayBuffer as binary', function(done) {
+    var buffer = new ArrayBuffer(4);
+    var dataview = new DataView(buffer);
+    for (var i = 0; i < buffer.byteLength ; i++) dataview.setInt8(i, i);
+
+    encode({ type: 'message', data: buffer }, true, function(encoded) {
+      var decoded = decode(encoded, 'arraybuffer');
+      expect(decoded).to.eql({ type: 'message', data: buffer });
+      expect(new Uint8Array(decoded.data)).to.eql(new Uint8Array(buffer));
+      done();
+    });
+  });
+
+  it('should encode/decode a typed array as binary', function(done) {
+    var buffer = new ArrayBuffer(32);
+    var typedArray = new Int32Array(buffer, 4, 2);
+    typedArray[0] = 1;
+    typedArray[1] = 2;
+
+    encode({ type: 'message', data: typedArray }, true, function(encoded) {
+      var decoded = decode(encoded, 'arraybuffer');
+      expect(decoded.type).to.eql('message');
+      expect(areArraysEqual(new Int32Array(decoded.data), typedArray)).to.eql(true);
+      done();
+    });
+  });
+
 });
+
+function areArraysEqual(x, y) {
+  if (x.length != y.length) return false;
+  for (var i = 0, l = x.length; i < l; i++) {
+    if (x[i] !== y[i]) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
When `supportsBinary` is false (in polling mode for example), ArrayBuffer was not properly converted to Buffer by this code:
```javascript
if (!Buffer.isBuffer(packet.data)) {
  var buf = new Buffer(packet.data.byteLength);
  for (var i = 0; i < buf.length; i++) {
    buf[i] = packet.data[i];
  }
  packet.data = buf;
}
```
The test `should encode/decode an ArrayBuffer as b64` should fail before this commit.
