### PR TITLE
Fix crashes in React Native "navigator is not defined"

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -16,7 +16,7 @@ var utf8 = require('utf8');
  * http://ghinda.net/jpeg-blob-ajax-android/
  */
 
-var isAndroid = navigator.userAgent.match(/Android/i);
+var isAndroid = /Android/i.test(navigator.userAgent);
 
 /**
  * Check if we are running in PhantomJS.

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -16,7 +16,7 @@ var utf8 = require('utf8');
  * http://ghinda.net/jpeg-blob-ajax-android/
  */
 
-var isAndroid = /Android/i.test(navigator.userAgent);
+var isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent);
 
 /**
  * Check if we are running in PhantomJS.
@@ -24,7 +24,7 @@ var isAndroid = /Android/i.test(navigator.userAgent);
  * https://github.com/ariya/phantomjs/issues/11395
  * @type boolean
  */
-var isPhantomJS = /PhantomJS/i.test(navigator.userAgent);
+var isPhantomJS = typeof navigator !== 'undefined' && /PhantomJS/i.test(navigator.userAgent);
 
 /**
  * When true, avoids using Blobs to encode payloads.


### PR DESCRIPTION
Ensures that `navigator` is defined before testing user agent so that Socket.io does not fail in React Native.

Tests are passing and I've also manually tested this and verified it works with React Native as expected.

Credit goes to @stevecass for originally reporting this over on Socket.io-client:
https://github.com/socketio/socket.io-client/issues/945