### PR TITLE
Require base64-arraybuffer module conditionally.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -5,9 +5,13 @@
 var keys = require('./keys');
 var hasBinary = require('has-binary');
 var sliceBuffer = require('arraybuffer.slice');
-var base64encoder = require('base64-arraybuffer');
 var after = require('after');
 var utf8 = require('utf8');
+
+var base64encoder;
+if (global.ArrayBuffer) {
+  base64encoder = require('base64-arraybuffer');
+}
 
 /**
  * Check if we are running an android browser. That requires us to use
@@ -262,7 +266,7 @@ exports.decodePacket = function (data, binaryType, utf8decode) {
 
 exports.decodeBase64Packet = function(msg, binaryType) {
   var type = packetslist[msg.charAt(0)];
-  if (!global.ArrayBuffer) {
+  if (!base64encoder) {
     return { type: type, data: { base64: true, data: msg.substr(1) } };
   }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "after": "0.8.1",
     "arraybuffer.slice": "0.0.6",
-    "base64-arraybuffer": "0.1.2",
+    "base64-arraybuffer": "0.1.5",
     "blob": "0.0.4",
     "has-binary": "0.1.6",
     "utf8": "2.1.0"


### PR DESCRIPTION
Since base64-arraybuffer version 0.1.5 introduced a change that fails at require time in a browser without ArrayBuffer support, the require must be guarded.

I verified that the existing tests fail on IE 8 once base64-arraybuffer is at 0.1.5 and that they no longer fail after the patch. This ought to help resolve socketio/engine.io#407.