### PR TITLE
Speed up travis build by caching node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 sudo: false
 node_js:
-- 0.10
-- 0.12
-- 4.0
-sudo: false
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
 notifications:
   irc: irc.freenode.org##socket.io
 matrix:
@@ -41,3 +41,6 @@ matrix:
     env: BROWSER_NAME=android BROWSER_VERSION=5.1
   - node_js: '0.12'
     env: BROWSER_NAME=android BROWSER_VERSION=latest
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
Reference: https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies

before: https://travis-ci.org/socketio/engine.io-parser/builds/149907299 (33min)
after: https://travis-ci.org/socketio/engine.io-parser/builds/150163153 (19min)
