### PR TITLE
decodePacket now accepts both Buffer and ArrayBuffer as data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,12 +153,7 @@ exports.decodePacket = function (data, binaryType, utf8decode) {
   }
 
   if (data instanceof ArrayBuffer) {
-    data = new DataView(data);
-    var newData = new Buffer(data.byteLength);
-    for (var i = 0; i < data.byteLength; i++) {
-      newData[i] = data.getInt8(i);
-    }
-    data = newData;
+    data = arrayBufferToBuffer(data);
   }
   var type = data[0];
   return { type: packetslist[type], data: data.slice(1) };

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,7 +153,12 @@ exports.decodePacket = function (data, binaryType, utf8decode) {
   }
 
   if (data instanceof ArrayBuffer) {
-    data = new Buffer(data);
+    data = new DataView(data);
+    var newData = new Buffer(data.byteLength);
+    for (var i = 0; i < data.byteLength; i++) {
+      newData[i] = data.getInt8(i);
+    }
+    data = newData;
   }
   var type = data[0];
   return { type: packetslist[type], data: data.slice(1) };

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,12 +146,14 @@ exports.decodePacket = function (data, binaryType, utf8decode) {
 
   // Binary data
   if (binaryType === 'arraybuffer') {
-    var type = data[0];
-    var intArray = new Uint8Array(data.length - 1);
-    for (var i = 1; i < data.length; i++) {
-      intArray[i - 1] = data[i];
-    }
-    return { type: packetslist[type], data: intArray.buffer };
+    //convert Buffer/ArrayBuffer data to Uint8Array
+    var intArray = new Uint8Array(data);
+    var type = intArray[0];
+    return { type: packetslist[type], data: intArray.buffer.slice(1) };
+  }
+
+  if (data instanceof ArrayBuffer) {
+    data = new Buffer(data);
   }
   var type = data[0];
   return { type: packetslist[type], data: data.slice(1) };

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -116,7 +116,7 @@ describe('parser', function() {
     });
   });
 
-  it('should decode an ArrayBuffer/Buffer with undeclared type as binary', function(done) {
+  it('should decode an ArrayBuffer/Buffer with undeclared type as binary', function() {
     var buffer1 = new ArrayBuffer(4);
     var dataview = new DataView(buffer1);
     var buffer2 = new Buffer(4);
@@ -131,10 +131,9 @@ describe('parser', function() {
     expect(new Uint8Array(decoded1.data)).to.eql(new Uint8Array(buffer1.slice(1)));
     expect(decoded2).to.eql({ type: 'message', data: new Buffer(buffer2.slice(1))});
     expect(new Uint8Array(decoded2.data)).to.eql(new Uint8Array(buffer2.slice(1)));
-    done();
   });
 
-  it('should decode an ArrayBuffer/Buffer as binary of type ArrayBuffer', function(done) {
+  it('should decode an ArrayBuffer/Buffer as binary of type ArrayBuffer', function() {
     var buffer1 = new ArrayBuffer(4);
     var dataview = new DataView(buffer1);
     var buffer2 = new Buffer(4);
@@ -156,7 +155,6 @@ describe('parser', function() {
     }
     expect(decoded2).to.eql({ type: 'message', data:  testBuffer});
     expect(new Uint8Array(decoded2.data)).to.eql(new Uint8Array(buffer2.slice(1)));
-    done();
   });
 
   it('should encode/decode a typed array as binary', function(done) {

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -116,6 +116,35 @@ describe('parser', function() {
     });
   });
 
+  it('should decode an ArrayBuffer/Buffer with undeclared type as binary', function(done) {
+    var buffer = new ArrayBuffer(4);
+    var dataview = new DataView(buffer);
+    for (var i = 0; i < buffer.byteLength ; i++) dataview.setInt8(i, 4-i);
+
+    var decoded1 = decode(buffer, null);
+    var decoded2 = decode(new Buffer(buffer), null);
+    expect(decoded1).to.eql({ type: 'message', data: new Buffer(buffer.slice(1))});
+    expect(new Uint8Array(decoded1.data)).to.eql(new Uint8Array(buffer.slice(1)));
+    expect(decoded2).to.eql({ type: 'message', data: new Buffer(buffer.slice(1))});
+    expect(new Uint8Array(decoded2.data)).to.eql(new Uint8Array(buffer.slice(1)));
+    done();
+  });
+
+  it('should decode an ArrayBuffer/Buffer as binary of type ArrayBuffer', function(done) {
+    var buffer1 = new ArrayBuffer(4);
+    var dataview = new DataView(buffer1);
+    for (var i = 0; i < buffer1.byteLength ; i++) dataview.setInt8(i, 4-i);
+    var buffer2 = new Buffer(buffer1);
+
+    var decoded1 = decode(buffer1, 'arraybuffer');
+    var decoded2 = decode(buffer2, 'arraybuffer');
+    expect(decoded1).to.eql({ type: 'message', data: buffer1.slice(1)});
+    expect(new Uint8Array(decoded1.data)).to.eql(new Uint8Array(buffer1.slice(1)));
+    expect(decoded2).to.eql({ type: 'message', data:  new ArrayBuffer(buffer2.slice(1))});
+    expect(new Uint8Array(decoded2.data)).to.eql(new Uint8Array(buffer2.slice(1)));
+    done();
+  });
+
   it('should encode/decode a typed array as binary', function(done) {
     var buffer = new ArrayBuffer(32);
     var typedArray = new Int32Array(buffer, 4, 2);

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -147,7 +147,14 @@ describe('parser', function() {
     var decoded2 = decode(buffer2, 'arraybuffer');
     expect(decoded1).to.eql({ type: 'message', data: buffer1.slice(1)});
     expect(new Uint8Array(decoded1.data)).to.eql(new Uint8Array(buffer1.slice(1)));
-    expect(decoded2).to.eql({ type: 'message', data:  new ArrayBuffer(buffer2.slice(1))});
+      
+    var testBuffer = new ArrayBuffer(decoded2.data.byteLength);
+    var decoded2view = new DataView(decoded2.data);
+    var testBufferview = new DataView(testBuffer);
+    for (var i = 0; i < decoded2view.byteLength ; i++) {
+        testBufferview.setInt8(i, decoded2view.getInt8(i));
+    }
+    expect(decoded2).to.eql({ type: 'message', data:  testBuffer});
     expect(new Uint8Array(decoded2.data)).to.eql(new Uint8Array(buffer2.slice(1)));
     done();
   });

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -117,24 +117,31 @@ describe('parser', function() {
   });
 
   it('should decode an ArrayBuffer/Buffer with undeclared type as binary', function(done) {
-    var buffer = new ArrayBuffer(4);
-    var dataview = new DataView(buffer);
-    for (var i = 0; i < buffer.byteLength ; i++) dataview.setInt8(i, 4-i);
+    var buffer1 = new ArrayBuffer(4);
+    var dataview = new DataView(buffer1);
+    var buffer2 = new Buffer(4);
+    for (var i = 0; i < buffer1.byteLength ; i++) {
+      dataview.setInt8(i, 4-i);
+      buffer2[i] = 4-i;
+    }
 
-    var decoded1 = decode(buffer, null);
-    var decoded2 = decode(new Buffer(buffer), null);
-    expect(decoded1).to.eql({ type: 'message', data: new Buffer(buffer.slice(1))});
-    expect(new Uint8Array(decoded1.data)).to.eql(new Uint8Array(buffer.slice(1)));
-    expect(decoded2).to.eql({ type: 'message', data: new Buffer(buffer.slice(1))});
-    expect(new Uint8Array(decoded2.data)).to.eql(new Uint8Array(buffer.slice(1)));
+    var decoded1 = decode(buffer1, null);
+    var decoded2 = decode(buffer2, null);
+    expect(decoded1).to.eql({ type: 'message', data: new Buffer([3,2,1])});
+    expect(new Uint8Array(decoded1.data)).to.eql(new Uint8Array(buffer1.slice(1)));
+    expect(decoded2).to.eql({ type: 'message', data: new Buffer(buffer2.slice(1))});
+    expect(new Uint8Array(decoded2.data)).to.eql(new Uint8Array(buffer2.slice(1)));
     done();
   });
 
   it('should decode an ArrayBuffer/Buffer as binary of type ArrayBuffer', function(done) {
     var buffer1 = new ArrayBuffer(4);
     var dataview = new DataView(buffer1);
-    for (var i = 0; i < buffer1.byteLength ; i++) dataview.setInt8(i, 4-i);
-    var buffer2 = new Buffer(buffer1);
+    var buffer2 = new Buffer(4);
+    for (var i = 0; i < buffer1.byteLength ; i++) {
+      dataview.setInt8(i, 4-i);
+      buffer2[i] = 4-i;
+    }
 
     var decoded1 = decode(buffer1, 'arraybuffer');
     var decoded2 = decode(buffer2, 'arraybuffer');


### PR DESCRIPTION
Potential fix for Issue #60.
