### PR TITLE
[chore] Use wtf-8 instead of utf8 to prevent lone surrogates from gen…

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -6,7 +6,7 @@ var keys = require('./keys');
 var hasBinary = require('has-binary');
 var sliceBuffer = require('arraybuffer.slice');
 var after = require('after');
-var utf8 = require('utf8');
+var utf8 = require('wtf-8');
 
 var base64encoder;
 if (global.ArrayBuffer) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var utf8 = require('utf8');
+var utf8 = require('wtf-8');
 var after = require('after');
 var keys = require('./keys');
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "base64-arraybuffer": "0.1.5",
     "blob": "0.0.4",
     "has-binary": "0.1.6",
-    "utf8": "2.1.0"
+    "wtf-8": "1.0.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
…erating parsing error

Note: sanitization should occur upfront

Closes https://github.com/socketio/engine.io-parser/pull/61, fixes (partially) https://github.com/socketio/socket.io/issues/2459