### PR TITLE
Fix double utf8 encoding for payloads

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -331,7 +331,7 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
   }
 
   function encodeOne(packet, doneCallback) {
-    exports.encodePacket(packet, !isBinary ? false : supportsBinary, true, function(message) {
+    exports.encodePacket(packet, !isBinary ? false : supportsBinary, false, function(message) {
       doneCallback(null, setLengthHeader(message));
     });
   }
@@ -407,7 +407,7 @@ exports.decodePayload = function (data, binaryType, callback) {
       }
 
       if (msg.length) {
-        packet = exports.decodePacket(msg, binaryType, true);
+        packet = exports.decodePacket(msg, binaryType, false);
 
         if (err.type == packet.type && err.data == packet.data) {
           // parser error in individual packet - ignoring payload

--- a/lib/index.js
+++ b/lib/index.js
@@ -226,7 +226,7 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
   }
 
   function encodeOne(packet, doneCallback) {
-    exports.encodePacket(packet, supportsBinary, true, function(message) {
+    exports.encodePacket(packet, supportsBinary, false, function(message) {
       doneCallback(null, setLengthHeader(message));
     });
   }
@@ -302,7 +302,7 @@ exports.decodePayload = function (data, binaryType, callback) {
       }
 
       if (msg.length) {
-        packet = exports.decodePacket(msg, binaryType, true);
+        packet = exports.decodePacket(msg, binaryType, false);
 
         if (err.type == packet.type && err.data == packet.data) {
           // parser error in individual packet - ignoring payload

--- a/test/parser.js
+++ b/test/parser.js
@@ -193,6 +193,12 @@ module.exports = function(parser) {
               });
           });
         });
+
+        it('should not utf8 encode when dealing with strings only', function() {
+          encPayload([{ type: 'message', data: '€€€' }, { type: 'message', data: 'α' }], function(data) {
+            expect(data).to.eql('4:4€€€2:4α');
+          });
+        });
       });
 
       describe('decoding error handling', function () {
@@ -255,13 +261,6 @@ module.exports = function(parser) {
           });
         });
 
-        it('should err on invalid utf8', function () {
-          decPayload('2:4\uffff', function (packet, index, total) {
-            var isLast = index + 1 == total;
-            expect(packet).to.eql(err);
-            expect(isLast).to.eql(true);
-          });
-        });
       });
     });
   });


### PR DESCRIPTION
Following https://github.com/socketio/engine.io-parser/issues/80

Currently, a payload containing only strings (no binary) transmitted over `polling` transport gets utf8 encoded / decoded twice, one by the transport (the content type is set to `text/plain; charset=UTF-8`) and one here (`encodePacket` is called with `utf8encode` to true).

Fixes https://github.com/socketio/engine.io/issues/315