### PR TITLE
Encode string payloads as strings even if binary supported

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
  */
 
 var utf8 = require('./utf8');
+var hasBinary = require('has-binary');
 var after = require('after');
 var keys = require('./keys');
 
@@ -217,7 +218,7 @@ exports.encodePayload = function (packets, supportsBinary, callback) {
     supportsBinary = null;
   }
 
-  if (supportsBinary) {
+  if (supportsBinary && hasBinary(packets)) {
     return exports.encodePayloadAsBinary(packets, callback);
   }
 

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -9,21 +9,3 @@ if (Blob) {
 }
 
 require('./base64_object.js');
-
-// General browser only tests
-var parser = require('../../');
-var encode = parser.encodePacket;
-var decode = parser.decodePacket;
-var encPayload = parser.encodePayload;
-var decPayload = parser.decodePayload;
-
-describe('basic functionality', function () {
-  it('should encode string payloads as strings even if binary supported', function (done) {
-    encPayload([{ type: 'ping' }, { type: 'post' }], true, function(data) {
-      expect(data).to.be.a('string');
-      done();
-    });
-  });
-});
-
-

--- a/test/parser.js
+++ b/test/parser.js
@@ -165,6 +165,15 @@ module.exports = function(parser) {
         });
       });
 
+      describe('basic functionality', function () {
+        it('should encode string payloads as strings even if binary supported', function (done) {
+          encPayload([{ type: 'ping' }, { type: 'post' }], true, function(data) {
+            expect(data).to.be.a('string');
+            done();
+          });
+        });
+      });
+
       describe('encoding and decoding', function () {
         var seen = 0;
         it('should encode/decode packets', function (done) {


### PR DESCRIPTION
This reverts commit 44c7aa5, which caused string payloads to be encoded as binary (so that huge string payloads were needlessly UTF-8-encoded).

Related: https://github.com/socketio/socket.io/issues/2872