### PR TITLE
Enable to utf8-decode string payloads

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -369,7 +369,7 @@ function map(ary, each, done) {
  * @api public
  */
 
-exports.decodePayload = function (data, binaryType, callback) {
+exports.decodePayload = function (data, binaryType, utf8decode, callback) {
   if (typeof data !== 'string') {
     return exports.decodePayloadAsBinary(data, binaryType, callback);
   }
@@ -379,10 +379,22 @@ exports.decodePayload = function (data, binaryType, callback) {
     binaryType = null;
   }
 
+  if (typeof utf8decode === 'function') {
+    callback = utf8decode;
+    utf8decode = null;
+  }
+
   var packet;
   if (data === '') {
     // parser error - ignoring payload
     return callback(err, 0, 1);
+  }
+
+  if (utf8decode) {
+    data = tryDecode(data);
+    if (data === false) {
+      return callback(err, 0, 1);
+    }
   }
 
   var length = '', n, msg;

--- a/lib/index.js
+++ b/lib/index.js
@@ -265,7 +265,7 @@ function map(ary, each, done) {
  * @api public
  */
 
-exports.decodePayload = function (data, binaryType, callback) {
+exports.decodePayload = function (data, binaryType, utf8decode, callback) {
   if (typeof data !== 'string') {
     return exports.decodePayloadAsBinary(data, binaryType, callback);
   }
@@ -275,9 +275,21 @@ exports.decodePayload = function (data, binaryType, callback) {
     binaryType = null;
   }
 
+  if (typeof utf8decode === 'function') {
+    callback = utf8decode;
+    utf8decode = null;
+  }
+
   if (data === '') {
     // parser error - ignoring payload
     return callback(err, 0, 1);
+  }
+
+  if (utf8decode) {
+    data = tryDecode(data);
+    if (data === false) {
+      return callback(err, 0, 1);
+    }
   }
 
   var length = '', n, msg, packet;


### PR DESCRIPTION
That will allow clients receiving the xhr payload with responseType = 'arraybuffer' to properly decode the message, which is not sent as binary by the backend anymore since 292c00c (#85).