### PR TITLE
[revert] "[fix] Enable to utf8-decode string payloads (#88)"

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -369,7 +369,7 @@ function map(ary, each, done) {
  * @api public
  */
 
-exports.decodePayload = function (data, binaryType, utf8decode, callback) {
+exports.decodePayload = function (data, binaryType, callback) {
   if (typeof data !== 'string') {
     return exports.decodePayloadAsBinary(data, binaryType, callback);
   }
@@ -379,22 +379,10 @@ exports.decodePayload = function (data, binaryType, utf8decode, callback) {
     binaryType = null;
   }
 
-  if (typeof utf8decode === 'function') {
-    callback = utf8decode;
-    utf8decode = null;
-  }
-
   var packet;
   if (data === '') {
     // parser error - ignoring payload
     return callback(err, 0, 1);
-  }
-
-  if (utf8decode) {
-    data = tryDecode(data);
-    if (data === false) {
-      return callback(err, 0, 1);
-    }
   }
 
   var length = '', n, msg;

--- a/lib/index.js
+++ b/lib/index.js
@@ -265,7 +265,7 @@ function map(ary, each, done) {
  * @api public
  */
 
-exports.decodePayload = function (data, binaryType, utf8decode, callback) {
+exports.decodePayload = function (data, binaryType, callback) {
   if (typeof data !== 'string') {
     return exports.decodePayloadAsBinary(data, binaryType, callback);
   }
@@ -275,21 +275,9 @@ exports.decodePayload = function (data, binaryType, utf8decode, callback) {
     binaryType = null;
   }
 
-  if (typeof utf8decode === 'function') {
-    callback = utf8decode;
-    utf8decode = null;
-  }
-
   if (data === '') {
     // parser error - ignoring payload
     return callback(err, 0, 1);
-  }
-
-  if (utf8decode) {
-    data = tryDecode(data);
-    if (data === false) {
-      return callback(err, 0, 1);
-    }
   }
 
   var length = '', n, msg, packet;


### PR DESCRIPTION
This reverts commit 278a7e45e71d905204e8efb1df95202040ebec28, which is now useless thanks to https://github.com/socketio/engine.io-client/pull/562.