### PR TITLE
perf: ponyfill Buffer.{allocUnsafe,from}

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,20 @@ var after = require('after');
 var keys = require('./keys');
 
 /**
+ * Buffer.allocUnsafe ponyfill.
+ */
+var allocUnsafe = Buffer.allocUnsafe ? function(n) {
+  return Buffer.allocUnsafe(n);
+} : function(n) {
+  return new Buffer(n);
+};
+var bufferFrom = Buffer.from ? function(x, y, z) {
+  return Buffer.from(x, y, z);
+} : function(x, y, z) {
+  return new Buffer(x, y, z);
+};
+
+/**
  * Current protocol version.
  */
 exports.protocol = 3;
@@ -88,7 +102,7 @@ function encodeBuffer(packet, supportsBinary, callback) {
   }
 
   var data = packet.data;
-  var typeBuffer = new Buffer(1);
+  var typeBuffer = allocUnsafe(1);
   typeBuffer[0] = packets[packet.type];
   return callback(Buffer.concat([typeBuffer, data]));
 }
@@ -181,7 +195,7 @@ function tryDecode(data) {
 
 exports.decodeBase64Packet = function(msg, binaryType) {
   var type = packetslist[msg.charAt(0)];
-  var data = new Buffer(msg.substr(1), 'base64');
+  var data = bufferFrom(msg.substr(1), 'base64');
   if (binaryType === 'arraybuffer') {
     var abv = new Uint8Array(data.length);
     for (var i = 0; i < abv.length; i++){
@@ -345,7 +359,7 @@ function bufferToString(buffer) {
  */
 
 function stringToBuffer(string) {
-  var buf = new Buffer(string.length);
+  var buf = allocUnsafe(string.length);
   for (var i = 0, l = string.length; i < l; i++) {
     buf.writeUInt8(string.charCodeAt(i), i);
   }
@@ -364,7 +378,7 @@ function arrayBufferToBuffer(data) {
   var array = new Uint8Array(data.buffer || data);
   var length = data.byteLength || data.length;
   var offset = data.byteOffset || 0;
-  var buffer = new Buffer(length);
+  var buffer = allocUnsafe(length);
 
   for (var i = 0; i < length; i++) {
     buffer[i] = array[offset + i];
@@ -388,7 +402,7 @@ function arrayBufferToBuffer(data) {
 
 exports.encodePayloadAsBinary = function (packets, callback) {
   if (!packets.length) {
-    return callback(new Buffer(0));
+    return callback(allocUnsafe(0));
   }
 
   map(packets, encodeOneBinaryPacket, function(err, results) {
@@ -404,7 +418,7 @@ function encodeOneBinaryPacket(p, doneCallback) {
     var sizeBuffer;
 
     if (typeof packet === 'string') {
-      sizeBuffer = new Buffer(encodingLength.length + 2);
+      sizeBuffer = allocUnsafe(encodingLength.length + 2);
       sizeBuffer[0] = 0; // is a string (not true binary = 0)
       for (var i = 0; i < encodingLength.length; i++) {
         sizeBuffer[i + 1] = parseInt(encodingLength[i], 10);
@@ -413,7 +427,7 @@ function encodeOneBinaryPacket(p, doneCallback) {
       return doneCallback(null, Buffer.concat([sizeBuffer, stringToBuffer(packet)]));
     }
 
-    sizeBuffer = new Buffer(encodingLength.length + 2);
+    sizeBuffer = allocUnsafe(encodingLength.length + 2);
     sizeBuffer[0] = 1; // is binary (true binary = 1)
     for (var i = 0; i < encodingLength.length; i++) {
       sizeBuffer[i + 1] = parseInt(encodingLength[i], 10);


### PR DESCRIPTION
`new Buffer` is deprecated and using it causes a performance hit in hot code. Running my engine for 20 seconds at moderate packet load generates this in the profiler:

![](https://i.imgur.com/uUoHq0U.png)

Almost 1% spent in that dumb deprecation warning.

This ponyfill for `Buffer.allocUnsafe` and `Buffer.from` will resolve the issue while maintaining backwards-compatibility.