### PR TITLE
Update test/parser.js should encode payloads as string: there is no type 'post'.

### DIFF
--- a/test/parser.js
+++ b/test/parser.js
@@ -158,7 +158,7 @@ module.exports = function(parser) {
     describe('payloads', function () {
       describe('basic functionality', function () {
         it('should encode payloads as strings', function (done) {
-          encPayload([{ type: 'ping' }, { type: 'post' }], function(data) {
+          encPayload([{ type: 'ping' }, { type: 'pong' }], function(data) {
             expect(data).to.be.a('string');
             done();
           });
@@ -167,7 +167,7 @@ module.exports = function(parser) {
 
       describe('basic functionality', function () {
         it('should encode string payloads as strings even if binary supported', function (done) {
-          encPayload([{ type: 'ping' }, { type: 'post' }], true, function(data) {
+          encPayload([{ type: 'ping' }, { type: 'pong' }], true, function(data) {
             expect(data).to.be.a('string');
             done();
           });


### PR DESCRIPTION
should encode payloads as string: there is no type 'post'.