### PR TITLE
fix: correct size message for binary

### DIFF
--- a/lib/encodePacket.browser.js
+++ b/lib/encodePacket.browser.js
@@ -25,7 +25,7 @@ const encodePacket = ({ type, data }, supportsBinary, callback) => {
     (data instanceof ArrayBuffer || isView(data))
   ) {
     if (supportsBinary) {
-      return callback(data instanceof ArrayBuffer ? data : data.buffer);
+      return callback(data instanceof ArrayBuffer ? data : data.slice().buffer);
     } else {
       return encodeBlobAsBase64(new Blob([data]), callback);
     }


### PR DESCRIPTION
Fix #122 
I made my [own parser](https://github.com/intech/socket.io-cbor-x-parser) and ran into a problem when working with binary data.
Reference a similar issue: https://github.com/protobufjs/protobuf.js/issues/852