### PR TITLE
Fix empty buffer case for Browser base64 encoding

### DIFF
--- a/lib/encodePacket.browser.ts
+++ b/lib/encodePacket.browser.ts
@@ -45,7 +45,7 @@ const encodeBlobAsBase64 = (
   const fileReader = new FileReader();
   fileReader.onload = function() {
     const content = (fileReader.result as string).split(",")[1];
-    callback("b" + content);
+    callback("b" + (content || ""));
   };
   return fileReader.readAsDataURL(data);
 };

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -97,6 +97,18 @@ describe("engine.io-parser (browser only)", () => {
           done();
         });
       });
+
+      it("should encode/decode a string + a 0-length ArrayBuffer payload", done => {
+        const packets: Packet[] = [
+          { type: "message", data: "test" },
+          { type: "message", data: createArrayBuffer([]) }
+        ];
+        encodePayload(packets, payload => {
+          expect(payload).to.eql("4test\x1eb");
+          expect(decodePayload(payload, "arraybuffer")).to.eql(packets);
+          done();
+        });
+      });
     }
   });
 });


### PR DESCRIPTION
Currently, passing an empty blob to encodeBlobAsBase64 results in "bundefined" getting passed
to the callback, because fileReader.result returns "data:" instead of the expected format:
"data:application/octet-stream;base64,<encoded bytes>"

This fix turns an "undefined" into "" so the callback is sent "b" (with is correctly decodes to [] by
the receivers) instead of "bundefined", which decodes to [0xba, 0x77, 0x5e, 0x7e, 0x29, 0xde]
